### PR TITLE
update llvm version to 13, fix tests for lreal/real conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
-inkwell = {git = "https://github.com/TheDan64/inkwell", branch="master", features=["llvm12-0"] }
+inkwell = {git = "https://github.com/TheDan64/inkwell", branch="master", features=["llvm13-0"] }
 rusty = {git = "https://github.com/PLC-lang/rusty", branch="master" } 
 
 [lib]


### PR DESCRIPTION
removed LREAL/REAL_TO_... overflow tests
the conversions fptosi/fptoui will return 'poison values' if the value can't fit in the target datatype
see following link https://llvm.org/docs/LangRef.html#fptosi-to-instruction