### PR TITLE
60 stdfunctions build fails after recent changes to rusty

### DIFF
--- a/src/bistable_functionblocks.rs
+++ b/src/bistable_functionblocks.rs
@@ -3,7 +3,7 @@
 pub struct SetResetParams {
     set: bool,
     reset: bool,
-    output: *mut bool,
+    output: bool,
 }
 
 impl Default for SetResetParams {
@@ -11,18 +11,14 @@ impl Default for SetResetParams {
         Self {
             set: Default::default(),
             reset: Default::default(),
-            output: std::ptr::null_mut(),
+            output: Default::default(),
         }
     }
 }
 
 impl SetResetParams {
     fn set_output(&mut self, value: bool) {
-        unsafe {
-            if !self.output.is_null() {
-                *self.output = value;
-            }
-        }
+        self.output = value;
     }
 }
 
@@ -35,7 +31,7 @@ impl SetResetParams {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn SR(params: &mut SetResetParams) {
-    params.set_output(params.set | (!params.reset & *params.output));
+    params.set_output(params.set | (!params.reset & params.output));
 }
 
 ///.
@@ -47,5 +43,5 @@ pub unsafe extern "C" fn SR(params: &mut SetResetParams) {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn RS(params: &mut SetResetParams) {
-    params.set_output(!params.reset & (params.set | *params.output));
+    params.set_output(!params.reset & (params.set | params.output));
 }

--- a/src/bistable_functionblocks.rs
+++ b/src/bistable_functionblocks.rs
@@ -1,19 +1,9 @@
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SetResetParams {
     set: bool,
     reset: bool,
     output: bool,
-}
-
-impl Default for SetResetParams {
-    fn default() -> Self {
-        Self {
-            set: Default::default(),
-            reset: Default::default(),
-            output: Default::default(),
-        }
-    }
 }
 
 impl SetResetParams {

--- a/src/counters.rs
+++ b/src/counters.rs
@@ -8,8 +8,8 @@ pub struct CTUParams<T> {
     cu: bool,
     r: bool,
     pv: T,
-    q: *mut bool,
-    cv: *mut T,
+    q: bool,
+    cv: T,
     internal: Signal,
 }
 
@@ -22,8 +22,8 @@ where
             cu: Default::default(),
             r: Default::default(),
             pv: Default::default(),
-            q: std::ptr::null_mut(),
-            cv: std::ptr::null_mut(),
+            q: Default::default(),
+            cv: Default::default(),
             internal: Default::default(),
         }
     }
@@ -34,21 +34,15 @@ where
     T: Integer + Copy,
 {
     unsafe fn update_q(&mut self) {
-        if !self.q.is_null() {
-            *self.q = *self.cv >= self.pv
-        }
+        self.q = self.cv >= self.pv
     }
 
     unsafe fn reset(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = Zero::zero();
-        }
+        self.cv = Zero::zero()
     }
 
     unsafe fn inc(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = *self.cv + One::one();
-        }
+        self.cv = self.cv + One::one();
     }
 
     fn r_edge(&mut self) -> bool {
@@ -62,7 +56,7 @@ where
 {
     if params.r {
         params.reset();
-    } else if params.r_edge() & (*params.cv < T::max_value()) {
+    } else if params.r_edge() & (params.cv < T::max_value()) {
         params.inc();
     }
     params.update_q();
@@ -146,8 +140,8 @@ pub struct CTDParams<T> {
     cd: bool,
     ld: bool,
     pv: T,
-    q: *mut bool,
-    cv: *mut T,
+    q: bool,
+    cv: T,
     internal: Signal,
 }
 
@@ -160,8 +154,8 @@ where
             cd: Default::default(),
             ld: Default::default(),
             pv: Default::default(),
-            q: std::ptr::null_mut(),
-            cv: std::ptr::null_mut(),
+            q: Default::default(),
+            cv: Default::default(),
             internal: Default::default(),
         }
     }
@@ -172,21 +166,15 @@ where
     T: Integer + Copy,
 {
     unsafe fn update_q(&mut self) {
-        if !self.q.is_null() {
-            *self.q = *self.cv <= Zero::zero();
-        }
+        self.q = self.cv <= Zero::zero()
     }
 
     unsafe fn load(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = self.pv;
-        }
+        self.cv = self.pv
     }
 
     unsafe fn dec(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = *self.cv - One::one();
-        }
+        self.cv = self.cv - One::one();
     }
 
     fn r_edge(&mut self) -> bool {
@@ -200,7 +188,7 @@ where
 {
     if params.ld {
         params.load();
-    } else if params.r_edge() & (*params.cv > T::min_value()) {
+    } else if params.r_edge() & (params.cv > T::min_value()) {
         params.dec();
     }
     params.update_q();
@@ -286,9 +274,9 @@ pub struct CTUDParams<T> {
     r: bool,
     ld: bool,
     pv: T,
-    qu: *mut bool,
-    qd: *mut bool,
-    cv: *mut T,
+    qu: bool,
+    qd: bool,
+    cv: T,
     internal_up: Signal,
     internal_down: Signal,
 }
@@ -304,9 +292,9 @@ where
             r: Default::default(),
             ld: Default::default(),
             pv: Default::default(),
-            qu: std::ptr::null_mut(),
-            qd: std::ptr::null_mut(),
-            cv: std::ptr::null_mut(),
+            qu: Default::default(),
+            qd: Default::default(),
+            cv: Default::default(),
             internal_up: Default::default(),
             internal_down: Default::default(),
         }
@@ -318,39 +306,27 @@ where
     T: Integer + Copy,
 {
     unsafe fn update_qu(&mut self) {
-        if !self.qu.is_null() {
-            *self.qu = *self.cv >= self.pv
-        }
+        self.qu = self.cv >= self.pv
     }
 
     unsafe fn update_qd(&mut self) {
-        if !self.qd.is_null() {
-            *self.qd = *self.cv <= Zero::zero();
-        }
+        self.qd = self.cv <= Zero::zero()
     }
 
     unsafe fn reset(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = Zero::zero();
-        }
+        self.cv = Zero::zero()
     }
 
     unsafe fn load(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = self.pv;
-        }
+        self.cv = self.pv
     }
 
     unsafe fn inc(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = *self.cv + One::one();
-        }
+        self.cv = self.cv + One::one();
     }
 
     unsafe fn dec(&mut self) {
-        if !self.cv.is_null() {
-            *self.cv = *self.cv - One::one();
-        }
+        self.cv = self.cv - One::one();
     }
 
     fn cu_r_edge(&mut self) -> bool {
@@ -374,9 +350,9 @@ where
         let r_edge_up = params.cu_r_edge();
         let r_edge_down = params.cd_r_edge();
         if !(r_edge_up & r_edge_down) {
-            if r_edge_up & (*params.cv < T::max_value()) {
+            if r_edge_up & (params.cv < T::max_value()) {
                 params.inc();
-            } else if r_edge_down & (*params.cv > T::min_value()) {
+            } else if r_edge_down & (params.cv > T::min_value()) {
                 params.dec();
             }
         }

--- a/src/flanks.rs
+++ b/src/flanks.rs
@@ -1,30 +1,16 @@
 use crate::utils::Signal;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[repr(C)]
 pub struct Trigger {
     clk: bool,
-    output: *mut bool,
+    output: bool,
     internal: Signal,
-}
-
-impl Default for Trigger {
-    fn default() -> Self {
-        Self {
-            clk: Default::default(),
-            output: std::ptr::null_mut(),
-            internal: Default::default(),
-        }
-    }
 }
 
 impl Trigger {
     fn set_output(&mut self, val: bool) {
-        if !self.output.is_null() {
-            unsafe {
-                *self.output = val;
-            }
-        }
+        self.output = val
     }
 }
 

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -13,28 +13,16 @@ pub mod test_time_helpers;
 pub type Time = i64;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TimerParams {
     input: bool,
     preset_time: Time,
-    output: *mut bool,
-    elapsed_time: *mut Time,
+    output: bool,
+    elapsed_time: Time,
     input_edge: Signal,
     start_time: Option<Instant>,
 }
 
-impl Default for TimerParams {
-    fn default() -> Self {
-        Self {
-            input: Default::default(),
-            preset_time: Default::default(),
-            output: std::ptr::null_mut(),
-            elapsed_time: std::ptr::null_mut(),
-            input_edge: Default::default(),
-            start_time: Default::default(),
-        }
-    }
-}
 
 impl TimerParams {
     /// This method returns true if the timer has already started
@@ -55,11 +43,7 @@ impl TimerParams {
     }
 
     fn set_elapsed_time(&mut self, duration: i64) {
-        unsafe {
-            if !self.elapsed_time.is_null() {
-                *self.elapsed_time = duration;
-            }
-        };
+        self.elapsed_time = duration;
     }
 
     /// Sets the elapsed time to either the preset time or the real elapsed time, whatever is smaller
@@ -84,11 +68,7 @@ impl TimerParams {
     }
 
     fn set_output(&mut self, value: bool) {
-        unsafe {
-            if !self.output.is_null() {
-                *self.output = value;
-            }
-        }
+        self.output = value;
     }
 
     fn input_rising_edge(&mut self) -> bool {

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -23,7 +23,6 @@ pub struct TimerParams {
     start_time: Option<Instant>,
 }
 
-
 impl TimerParams {
     /// This method returns true if the timer has already started
     /// It does not take into consideration the preset/range for the timer

--- a/tests/bistable_functionblocks_tests.rs
+++ b/tests/bistable_functionblocks_tests.rs
@@ -37,19 +37,15 @@ fn sr() {
 			f_f_t  : BOOL;
 			f_f_f  : BOOL;
 		END_VAR
-			t_t_t := TRUE;
-			t_f_t := TRUE;
-			f_t_t := TRUE;
-			f_f_t := TRUE;
-
-			sr_inst(SET1 := TRUE, RESET := TRUE, Q1 => t_t_t);
-			sr_inst(SET1 := TRUE, RESET := TRUE, Q1 => t_t_f);
-			sr_inst(SET1 := TRUE, RESET := FALSE, Q1 => t_f_t);
-			sr_inst(SET1 := TRUE, RESET := FALSE, Q1 => t_f_f);
-			sr_inst(SET1 := FALSE, RESET := TRUE, Q1 => f_t_t);
-			sr_inst(SET1 := FALSE, RESET := TRUE, Q1 => f_t_f);
-			sr_inst(SET1 := FALSE, RESET := FALSE, Q1 => f_f_t);
-			sr_inst(SET1 := FALSE, RESET := FALSE, Q1 => f_f_f);
+			sr_inst(SET1 := TRUE, RESET := TRUE, Q1 => t_t_f); (* Q is in default state, S and R are asserted -> Q goes high *)
+			sr_inst(SET1 := FALSE, RESET := TRUE, Q1 => f_t_t); (* Q is high, R is asserted -> Q goes low *)
+			sr_inst(SET1 := FALSE, RESET := FALSE, Q1 => f_f_f); (* Q is low, neither S nor R are asserted -> Q stays low*)
+			sr_inst(SET1 := TRUE, RESET := FALSE, Q1 => t_f_f); (* Q is low, S is asserted -> Q goes high *)
+			sr_inst(SET1 := TRUE, RESET := TRUE, Q1 => t_t_t); (* Q is high, S and R are asserted -> Q stays high *)
+			sr_inst(SET1 := TRUE, RESET := FALSE, Q1 => t_f_t); (* Q is high, S is asserted -> Q stays high *)
+			sr_inst(SET1 := FALSE, RESET := FALSE, Q1 => f_f_t); (* Q is high, neither S nor R are asserted -> Q stays high *)
+            sr_inst(SET1 := FALSE, RESET := TRUE, Q1 => f_t_f); (* reset *)
+			sr_inst(SET1 := FALSE, RESET := TRUE, Q1 => f_t_f); (* Q is low, R is asserted -> Q stays low *)
         END_PROGRAM
     "#;
 
@@ -60,15 +56,14 @@ fn sr() {
         ..MainType::default()
     };
     run::<_, ()>(&exec_engine, "main", &mut main_inst);
-    assert!(main_inst.t_t_t);
     assert!(main_inst.t_t_f);
-    assert!(main_inst.t_f_t);
-    assert!(main_inst.t_f_f);
-
     assert!(!main_inst.f_t_t);
-    assert!(!main_inst.f_t_f);
-    assert!(main_inst.f_f_t);
     assert!(!main_inst.f_f_f);
+    assert!(main_inst.t_f_f);
+    assert!(main_inst.t_t_t);
+    assert!(main_inst.t_f_t);
+    assert!(main_inst.f_f_t);
+    assert!(!main_inst.f_t_f);
 }
 
 #[test]
@@ -86,19 +81,15 @@ fn rs() {
 			f_f_t  : BOOL;
 			f_f_f  : BOOL;
 		END_VAR
-			t_t_t := TRUE;
-			t_f_t := TRUE;
-			f_t_t := TRUE;
-			f_f_t := TRUE;
-
-			rs_inst(SET := TRUE, RESET1 := TRUE, Q1 => t_t_t);
-			rs_inst(SET := TRUE, RESET1 := TRUE, Q1 => t_t_f);
-			rs_inst(SET := TRUE, RESET1 := FALSE, Q1 => t_f_t);
-			rs_inst(SET := TRUE, RESET1 := FALSE, Q1 => t_f_f);
-			rs_inst(SET := FALSE, RESET1 := TRUE, Q1 => f_t_t);
-			rs_inst(SET := FALSE, RESET1 := TRUE, Q1 => f_t_f);
-			rs_inst(SET := FALSE, RESET1 := FALSE, Q1 => f_f_t);
-			rs_inst(SET := FALSE, RESET1 := FALSE, Q1 => f_f_f);
+            rs_inst(SET := TRUE, RESET1 := TRUE, Q1 => t_t_f); (* Q is in default state, S and R are asserted -> Q stays low *)
+            rs_inst(SET := FALSE, RESET1 := FALSE, Q1 => f_f_f); (* Q is low, neither S nor R are asserted -> Q stays low*)
+            rs_inst(SET := TRUE, RESET1 := FALSE, Q1 => t_f_f); (* Q is low, S is asserted -> Q goes high *)
+            rs_inst(SET := FALSE, RESET1 := TRUE, Q1 => f_t_t); (* Q is high, R is asserted -> Q goes low *)
+            rs_inst(SET := FALSE, RESET1 := TRUE, Q1 => f_t_f); (* Q is low, R is asserted -> Q stays low *)
+            rs_inst(SET := TRUE, RESET1 := FALSE, Q1 => t_f_t); (* set *)
+            rs_inst(SET := TRUE, RESET1 := FALSE, Q1 => t_f_t); (* Q is high, S is asserted -> Q stays high *)
+            rs_inst(SET := FALSE, RESET1 := FALSE, Q1 => f_f_t); (* Q is high, neither S nor R are asserted -> Q stays high *)
+            rs_inst(SET := TRUE, RESET1 := TRUE, Q1 => t_t_t); (* Q is high, S and R are asserted -> Q goes low *)
         END_PROGRAM
     "#;
 
@@ -109,13 +100,12 @@ fn rs() {
         ..MainType::default()
     };
     run::<_, ()>(&exec_engine, "main", &mut main_inst);
-    assert!(!main_inst.t_t_t);
     assert!(!main_inst.t_t_f);
-    assert!(main_inst.t_f_t);
+    assert!(!main_inst.f_f_f);
     assert!(main_inst.t_f_f);
-
     assert!(!main_inst.f_t_t);
     assert!(!main_inst.f_t_f);
+    assert!(main_inst.t_f_t);
     assert!(main_inst.f_f_t);
-    assert!(!main_inst.f_f_f);
+    assert!(!main_inst.t_t_t);
 }


### PR DESCRIPTION
Recent rusty changes to the way VAR_OUTPUT variables are handled broke many of the standard function implementations.
This PR fixes that.